### PR TITLE
Adding retry logic to cache fallback, handling fallback on cache calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,5 @@ vendor/
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file
 composer.lock
 
+# PHPUnit
+/.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "fingo/laravel-cache-fallback",
+  "name": "packbackbooks/laravel-cache-fallback",
   "type": "library",
   "description": "Provides fallback mechanisms for cache handlers",
   "keywords": [
@@ -20,13 +20,13 @@
     }
   ],
   "require": {
-    "php": "~5.6|~7.0",
-    "illuminate/cache": "~5.1"
+    "php": "^7.1",
+    "illuminate/cache": "5.5.*|5.6.*|5.7.*|5.8.*"
   },
   "require-dev": {
-    "phpunit/phpunit": "^5.2.9",
-    "orchestra/testbench": "^3.2.2",
-    "mockery/mockery": "^0.9.4"
+    "phpunit/phpunit": "^8.0",
+    "orchestra/testbench": "^3.8",
+    "mockery/mockery": "^1.2"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,6 @@
     }
   },
   "scripts": {
-    "test": "phpunit --bootstrap=vendor/autoload.php tests"
+    "test": "phpunit"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
   "require-dev": {
     "phpunit/phpunit": "^8.0",
     "orchestra/testbench": "^3.8",
-    "mockery/mockery": "^1.2"
+    "mockery/mockery": "^1.2",
+    "predis/predis": "^1.1.1"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "packbackbooks/laravel-cache-fallback",
+  "name": "fingo/laravel-cache-fallback",
   "type": "library",
   "description": "Provides fallback mechanisms for cache handlers",
   "keywords": [

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<ruleset name="laravel-cache-fallback">
+    <description>The coding standard of the laravel-cache-fallback package</description>
+    <arg value="p" />
+
+    <config name="ignore_warnings_on_exit" value="1" />
+    <config name="ignore_errors_on_exit" value="1" />
+
+    <arg name="colors" />
+    <arg value="s" />
+
+    <!-- Use the PSR2 Standard-->
+    <rule ref="PSR2" />
+</ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php"
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         verbose="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false">
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src/</directory>
+        </whitelist>
+    </filter>
+    <logging>
+        <log type="junit" target="build/report.junit.xml"/>
+        <log type="coverage-html" target="build/coverage"/>
+        <log type="coverage-text" target="build/coverage.txt"/>
+        <log type="coverage-clover" target="build/logs/clover.xml"/>
+    </logging>
+</phpunit>

--- a/src/CacheFallback.php
+++ b/src/CacheFallback.php
@@ -30,7 +30,8 @@ class CacheFallback extends CacheManager
                 return parent::__call($method, $parameters);
             } catch (CommunicationException $e) {
                 // Only retry if we got a connection error, to avoid other errors from doing unwanted retries
-                return retry($attempts, function () use ($method, $parameters) {
+                // We are subtracting from $attempts since we already have completed 1 attempt on line 30
+                return retry($attempts-1, function () use ($method, $parameters) {
                     return parent::__call($method, $parameters);
                 }, $interval);
             }
@@ -97,7 +98,7 @@ class CacheFallback extends CacheManager
     protected function createRedisDriver(array $config)
     {
         $redisDriver = parent::createRedisDriver($config);
-        $redisDriver->get('test');
+        $redisDriver->connection()->ping();
         return $redisDriver;
     }
 

--- a/src/CacheFallback.php
+++ b/src/CacheFallback.php
@@ -56,6 +56,7 @@ class CacheFallback extends CacheManager
     {
         $attempts = config('cache_fallback.attempts_before_fallback');
         $interval = config('cache_fallback.interval_between_attempts');
+        // Handle errors during initalization of the cache store
         try {
             return retry($attempts, function () use ($name) {
                 return parent::resolve($name);

--- a/src/CacheFallback.php
+++ b/src/CacheFallback.php
@@ -37,7 +37,6 @@ class CacheFallback extends CacheManager
      */
     private function callFallback($method, $parameters)
     {
-
         // We have two levels of try-catches since we are catching different exception types
         try {
             try {

--- a/src/CacheFallback.php
+++ b/src/CacheFallback.php
@@ -4,6 +4,8 @@ namespace Fingo\LaravelCacheFallback;
 
 use Exception;
 use Illuminate\Cache\CacheManager;
+use Illuminate\Support\Facades\Log;
+use Predis\CommunicationException;
 
 /**
  * Class CacheFallback
@@ -11,6 +13,38 @@ use Illuminate\Cache\CacheManager;
  */
 class CacheFallback extends CacheManager
 {
+    /**
+     * Dynamically call the default driver instance.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        $attempts = config('cache_fallback.attempts_before_fallback');
+        $interval = config('cache_fallback.interval_between_attempts');
+        // We have two levels of try-catches since we are catching different exception types
+        try {
+            try {
+                return parent::__call($method, $parameters);
+            } catch (CommunicationException $e) {
+                // Only retry if we got a connection error, to avoid other errors from doing unwanted retries
+                return retry($attempts, function () use ($method, $parameters) {
+                    return parent::__call($method, $parameters);
+                }, $interval);
+            }
+        } catch (Exception $e) {
+            report($e);
+
+            if ($newDriver = $this->nextDriver($this->getDefaultDriver())) {
+                return $this->store($newDriver)->$method(...$parameters);
+            }
+            // Throw the exception if we have exhaused all our options
+            throw $e;
+        }
+    }
+
     /**
      * Resolve the given store.
      *
@@ -20,12 +54,19 @@ class CacheFallback extends CacheManager
      */
     protected function resolve($name)
     {
+        $attempts = config('cache_fallback.attempts_before_fallback');
+        $interval = config('cache_fallback.interval_between_attempts');
         try {
-            return parent::resolve($name);
+            return retry($attempts, function () use ($name) {
+                return parent::resolve($name);
+            }, $interval);
         } catch (Exception $e) {
+            report($e);
+
             if ($newDriver = $this->nextDriver($name)) {
                 return $this->resolve($newDriver);
             }
+            // Throw the exception if we have exhaused all our options
             throw $e;
         }
     }

--- a/src/CacheFallbackFacade.php
+++ b/src/CacheFallbackFacade.php
@@ -14,6 +14,7 @@ class CacheFallbackFacade extends Facade
      * Get the registered name of the component.
      *
      * @return string
+     * @codeCoverageIgnore
      */
     protected static function getFacadeAccessor()
     {

--- a/src/CacheFallbackServiceProvider.php
+++ b/src/CacheFallbackServiceProvider.php
@@ -34,6 +34,7 @@ class CacheFallbackServiceProvider extends CacheServiceProvider
     public function register()
     {
         $this->mergeConfigFrom(__DIR__ . '/config/cache_fallback.php', 'cache_fallback');
+
         $this->app->singleton('cache', function ($app) {
             return new CacheFallback($app);
         });
@@ -45,7 +46,5 @@ class CacheFallbackServiceProvider extends CacheServiceProvider
         $this->app->singleton('memcached.connector', function () {
             return new MemcachedConnector;
         });
-
-        $this->registerCommands();
     }
 }

--- a/src/config/cache_fallback.php
+++ b/src/config/cache_fallback.php
@@ -8,5 +8,7 @@ return [
         'cookie',
         'file',
         'array'
-    ]
+    ],
+    'attempts_before_fallback' => 3,
+    'interval_between_attempts' => 20, // in milliseconds
 ];

--- a/src/config/cache_fallback.php
+++ b/src/config/cache_fallback.php
@@ -1,6 +1,18 @@
 <?php
 
 return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Cache Driver Fallback Order
+    |--------------------------------------------------------------------------
+    |
+    | Here you may list all the possible cache drivers you want to use,
+    | in the order you want to fall back to them on. The package will go
+    | down the list until it finds a working cache driver.
+    |
+    */
+
     'fallback_order' => [
         'redis',
         'memcached',
@@ -9,6 +21,46 @@ return [
         'file',
         'array'
     ],
-    'attempts_before_fallback' => 3,
-    'interval_between_attempts' => 20, // in milliseconds
+
+    /*
+    |--------------------------------------------------------------------------
+    | Attempts Before Fallback
+    |--------------------------------------------------------------------------
+    |
+    | In some cases, such as connection timeout errors, retrying whatever
+    | operation we performed (e.g. trying to instantiate a driver) will
+    | get rid of whatever exception came up initially. This setting can be
+    | configured to the number of attempts that should be made before a
+    | fallback occurs.
+    |
+    */
+    'attempts_before_fallback' => 0,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Interval Between Attempts
+    |--------------------------------------------------------------------------
+    |
+    | This defines, in milliseconds, how long we should wait before
+    | performing our retries. See the previous configuration comment for
+    | why we may want this.
+    |
+    */
+    'interval_between_attempts' => 20,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Fallback On __call() Failure
+    |--------------------------------------------------------------------------
+    |
+    | After a cache driver is instantiated and we have a connection to it,
+    | that connection may get lost due to various reasons. By default,
+    | this will do the normal behavior of triggering an exception, but
+    | it is possible for this to have the same fallback behavior apply as
+    | during cache store instantiation, so for example Cache::get() will
+    | fallback to alternatives.
+    |
+    */
+    'fallback_on_call_failure' => false,
+
 ];

--- a/tests/CacheFallbackTest.php
+++ b/tests/CacheFallbackTest.php
@@ -12,7 +12,7 @@ class CacheFallbackTest extends TestCase
 
     protected $application;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->application = $this->createApplication();

--- a/tests/CacheFallbackTest.php
+++ b/tests/CacheFallbackTest.php
@@ -29,6 +29,8 @@ class CacheFallbackTest extends TestCase
     {
         $app['config']->set('cache.default', 'redis');
         $app['config']->set('app.key', 'hh8oYDaXmHZQ6uNhaq7HWtpDDucMtD5C');
+        $app['config']->set('cache_fallback.attempts_before_fallback', 3);
+        $app['config']->set('cache_fallback.fallback_on_call_failure', true);
     }
 
     protected function getPackageProviders($app)


### PR DESCRIPTION
## Summary of Changes

This PR does a few things:
- updates the package to work with Laravel 5.5+
- adds retry logic to the resolve() function
- introduces error handling/fallbacks and retries to any cache calls
- improves config file documentation
- gets all tests to pass w/ newest PHPUnit

## Testing

- [ ] Functional tests
- [x] Unit tests
- [x] Manual tests
- [ ] Other (describe...)

New tests were written to handle the __call cases, and other tests were updated. All flows are now covered. I've also verified this manually in one of our apps.

## PR Checklist

- [x] My code adheres to [Packback's code styling and standards](https://sites.google.com/a/packback.co/engineering-process/engineering-technical-docs/code-style-guides). If not, add an explanation for why it doesn't.
- [x] I have selected at least one primary assignee for this PR. All of these people need to approve the pull request before it is merged.
- [x] I have selected any number of reviewers for this pull request.  Reviewers are people who should know about the pull request, but whose sign-off is not a blocker to merging.
- [ ] If this is a BUG that was found outside of development, I have added some text describing how it got through our tests, and how we will prevent similar issues in the future.

## PR Dependencies

<!-- Optional. If this pull request cannot be merged until others are merged, link them here --> 